### PR TITLE
챌린지 상세화면 구성

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,8 @@
     <application
         android:label="tracky_flutter"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:enableOnBackInvokedCallback="true">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/lib/ui/pages/community/challenge/detail_page/detail_page.dart
+++ b/lib/ui/pages/community/challenge/detail_page/detail_page.dart
@@ -3,15 +3,19 @@ import 'package:flutter/material.dart';
 class ChallengeDetailPage extends StatelessWidget {
   final String title;
   final String dDay;
-  final String? progress; // optional
-  final String? desc;
+  final String progress;
+  final String totalDistance;
+  final String desc;
+  final bool isJoined;
 
   const ChallengeDetailPage({
     super.key,
     required this.title,
     required this.dDay,
-    this.progress,
-    this.desc,
+    required this.progress,
+    required this.totalDistance,
+    required this.desc,
+    required this.isJoined,
   });
 
   @override
@@ -20,64 +24,80 @@ class ChallengeDetailPage extends StatelessWidget {
       appBar: AppBar(
         leading: const BackButton(),
         actions: [
-          IconButton(icon: const Icon(Icons.more_vert), onPressed: () {}),
+          IconButton(
+            icon: const Icon(Icons.more_vert),
+            onPressed: () => _showChallengeOptions(context),
+          ),
         ],
-        backgroundColor: Colors.white,
+        backgroundColor: const Color(0xFFF9FAEB),
         elevation: 0,
       ),
+      backgroundColor: const Color(0xFFF9FAEB),
       body: SingleChildScrollView(
-        padding: const EdgeInsets.fromLTRB(24, 0, 24, 100), // 하단 버튼 고려한 패딩
+        padding: const EdgeInsets.fromLTRB(24, 0, 24, 100),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             const SizedBox(height: 16),
-            Center(
-              child: Placeholder(), // 이미지 Placeholder
-            ),
+            const Center(child: Placeholder()),
+
             const SizedBox(height: 16),
             Center(
               child: Text(dDay, style: const TextStyle(color: Colors.grey, fontSize: 14)),
             ),
+
             const SizedBox(height: 8),
             Center(
-              child: Text(title,
-                  style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+              child: Text(
+                title,
+                style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+              ),
             ),
+
             const SizedBox(height: 8),
-            if (desc != null)
-              Center(
-                child: Text(desc!, style: const TextStyle(fontSize: 14)),
-              ),
-            const SizedBox(height: 16),
-            if (desc != null)
-              Text(
-                "$desc\n이번 달에 목표를 달성하고 완주자 기록을 달성하세요.",
+            Center(
+              child: Text(
+                desc,
+                style: const TextStyle(fontSize: 14),
                 textAlign: TextAlign.center,
-                style: const TextStyle(fontSize: 14, color: Colors.black87),
               ),
+            ),
+            const SizedBox(height: 4),
+            const Center(
+              child: Text(
+                "이번 달에 목표를 달성하고 완주자 기록을 달성하세요.",
+                style: TextStyle(fontSize: 14, color: Colors.black87),
+                textAlign: TextAlign.center,
+              ),
+            ),
+
             const SizedBox(height: 32),
             const Text("총 거리", style: TextStyle(color: Colors.grey)),
             Text(
-              progress?.split('/').last.trim() ?? '100.0km',
+              totalDistance,
               style: const TextStyle(fontSize: 16),
             ),
+
+            if (isJoined) ...[
+              const SizedBox(height: 16),
+              const Text("달린 거리", style: TextStyle(color: Colors.grey)),
+              Text(progress, style: const TextStyle(fontSize: 16)),
+            ],
+
             const SizedBox(height: 16),
             const Text("운동 기간", style: TextStyle(color: Colors.grey)),
             const Text("6월 1일~30일", style: TextStyle(fontSize: 16)),
+
             const SizedBox(height: 16),
             const Text("참가자", style: TextStyle(color: Colors.grey)),
             const Text("42,049명", style: TextStyle(fontSize: 16)),
+
             const SizedBox(height: 32),
-            const Text("리워드 획득",
-                style: TextStyle(fontWeight: FontWeight.bold)),
+            const Text("리워드 획득", style: TextStyle(fontWeight: FontWeight.bold)),
             const SizedBox(height: 12),
             Row(
               children: [
-                const SizedBox(
-                  width: 40,
-                  height: 40,
-                  child: Placeholder(),
-                ),
+                const SizedBox(width: 40, height: 40, child: Placeholder()),
                 const SizedBox(width: 16),
                 Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
@@ -105,4 +125,93 @@ class ChallengeDetailPage extends StatelessWidget {
       ),
     );
   }
+
+  void _showChallengeOptions(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      backgroundColor: Colors.transparent,
+      builder: (context) {
+        return SafeArea(
+          child: Container(
+            margin: const EdgeInsets.all(8),
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                ListTile(
+                  title: const Center(
+                    child: Text(
+                      "챌린지 정보",
+                      style: TextStyle(
+                        fontSize: 20,
+                        fontWeight: FontWeight.w500,
+                        color: Colors.blue,
+                      ),
+                    ),
+                  ),
+                  onTap: () {
+                    Navigator.pop(context);
+                    debugPrint("챌린지 정보 보기");
+                  },
+                ),
+                const Divider(height: 1, thickness: 1),
+                if (isJoined)
+                  ListTile(
+                    title: const Center(
+                      child: Text(
+                        "챌린지 종료",
+                        style: TextStyle(
+                          fontSize: 20,
+                          fontWeight: FontWeight.w500,
+                          color: Colors.red,
+                        ),
+                      ),
+                    ),
+                    onTap: () {
+                      Navigator.pop(context);
+                      debugPrint("챌린지 종료");
+                    },
+                  ),
+                if (!isJoined)
+                  ListTile(
+                    title: const Center(
+                      child: Text(
+                        "챌린지 참가",
+                        style: TextStyle(
+                          fontSize: 20,
+                          fontWeight: FontWeight.w500,
+                          color: Colors.blue,
+                        ),
+                      ),
+                    ),
+                    onTap: () {
+                      Navigator.pop(context);
+                      debugPrint("챌린지 참가");
+                    },
+                  ),
+                const Divider(height: 1),
+                ListTile(
+                  title: const Center(
+                    child: Text(
+                      "취소",
+                      style: TextStyle(
+                        fontSize: 18,
+                        color: Colors.blue,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ),
+                  onTap: () => Navigator.pop(context),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
 }
+

--- a/lib/ui/pages/community/challenge/detail_page/detail_page.dart
+++ b/lib/ui/pages/community/challenge/detail_page/detail_page.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+
+class ChallengeDetailPage extends StatelessWidget {
+  final String title;
+  final String dDay;
+  final String? progress; // optional
+  final String? desc;
+
+  const ChallengeDetailPage({
+    super.key,
+    required this.title,
+    required this.dDay,
+    this.progress,
+    this.desc,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        leading: const BackButton(),
+        actions: [
+          IconButton(icon: const Icon(Icons.more_vert), onPressed: () {}),
+        ],
+        backgroundColor: Colors.white,
+        elevation: 0,
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.fromLTRB(24, 0, 24, 100), // 하단 버튼 고려한 패딩
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const SizedBox(height: 16),
+            Center(
+              child: Placeholder(), // 이미지 Placeholder
+            ),
+            const SizedBox(height: 16),
+            Center(
+              child: Text(dDay, style: const TextStyle(color: Colors.grey, fontSize: 14)),
+            ),
+            const SizedBox(height: 8),
+            Center(
+              child: Text(title,
+                  style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+            ),
+            const SizedBox(height: 8),
+            if (desc != null)
+              Center(
+                child: Text(desc!, style: const TextStyle(fontSize: 14)),
+              ),
+            const SizedBox(height: 16),
+            if (desc != null)
+              Text(
+                "$desc\n이번 달에 목표를 달성하고 완주자 기록을 달성하세요.",
+                textAlign: TextAlign.center,
+                style: const TextStyle(fontSize: 14, color: Colors.black87),
+              ),
+            const SizedBox(height: 32),
+            const Text("총 거리", style: TextStyle(color: Colors.grey)),
+            Text(
+              progress?.split('/').last.trim() ?? '100.0km',
+              style: const TextStyle(fontSize: 16),
+            ),
+            const SizedBox(height: 16),
+            const Text("운동 기간", style: TextStyle(color: Colors.grey)),
+            const Text("6월 1일~30일", style: TextStyle(fontSize: 16)),
+            const SizedBox(height: 16),
+            const Text("참가자", style: TextStyle(color: Colors.grey)),
+            const Text("42,049명", style: TextStyle(fontSize: 16)),
+            const SizedBox(height: 32),
+            const Text("리워드 획득",
+                style: TextStyle(fontWeight: FontWeight.bold)),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                const SizedBox(
+                  width: 40,
+                  height: 40,
+                  child: Placeholder(),
+                ),
+                const SizedBox(width: 16),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(title),
+                    const Text("달성", style: TextStyle(color: Colors.grey)),
+                  ],
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
+      floatingActionButton: SizedBox(
+        width: MediaQuery.of(context).size.width * 0.9,
+        height: 50,
+        child: FloatingActionButton.extended(
+          backgroundColor: Colors.pinkAccent,
+          onPressed: () {
+            // 참여 로직
+          },
+          label: const Text("챌린지 참여하기", style: TextStyle(fontSize: 16)),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/pages/community/challenge/list_page.dart
+++ b/lib/ui/pages/community/challenge/list_page.dart
@@ -8,17 +8,73 @@ class ChallengeListPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final myChallenges = [
-      {"title": "6월 100K 챌린지", "progress": "23.4 / 100.0km", "dDay": "13일 남음"},
-      {"title": "6월 30K 챌린지", "progress": "12.0 / 30.0km", "dDay": "13일 남음"},
+      {
+        "title": "6월 100K 챌린지",
+        "desc": "이번 달 100km를 달려보세요.",
+        "totalDistance": "100.0km",
+        "progress": "23.4km",
+        "dDay": "13일 남음",
+        "joined": true,
+      },
+      {
+        "title": "6월 30K 챌린지",
+        "desc": "이번 달 30km를 달려보세요.",
+        "totalDistance": "30.0km",
+        "progress": "12.0km",
+        "dDay": "13일 남음",
+        "joined": true,
+      },
     ];
 
     final joinableChallenges = [
-      {"title": "6월 주간 챌린지", "desc": "이번 주 5km를 달려보세요.", "dDay": "5일 남음"},
-      {"title": "6월 주간 챌린지", "desc": "이번 주 15km를 달려보세요.", "dDay": "5일 남음"},
-      {"title": "6월 주간 챌린지", "desc": "이번 주 10km를 달려보세요.", "dDay": "5일 남음"},
-      {"title": "6월 100K 챌린지", "desc": "이번 달 100km를 달려보세요.", "dDay": "13일 남음"},
-      {"title": "6월 25K 챌린지", "desc": "이번 달 25km를 달려보세요.", "dDay": "13일 남음"},
-      {"title": "6월 30K 챌린지", "desc": "이번 달 30km를 달려보세요.", "dDay": "13일 남음"},
+      {
+        "title": "6월 주간 챌린지",
+        "desc": "이번 주 5km를 달려보세요.",
+        "totalDistance": "5.0km",
+        "progress": "0.0km",
+        "dDay": "5일 남음",
+        "joined": false,
+      },
+      {
+        "title": "6월 주간 챌린지",
+        "desc": "이번 주 15km를 달려보세요.",
+        "totalDistance": "15.0km",
+        "progress": "0.0km",
+        "dDay": "5일 남음",
+        "joined": false,
+      },
+      {
+        "title": "6월 주간 챌린지",
+        "desc": "이번 주 10km를 달려보세요.",
+        "totalDistance": "10.0km",
+        "progress": "0.0km",
+        "dDay": "5일 남음",
+        "joined": false,
+      },
+      {
+        "title": "6월 100K 챌린지",
+        "desc": "이번 달 100km를 달려보세요.",
+        "totalDistance": "100.0km",
+        "progress": "0.0km",
+        "dDay": "13일 남음",
+        "joined": false,
+      },
+      {
+        "title": "6월 25K 챌린지",
+        "desc": "이번 달 25km를 달려보세요.",
+        "totalDistance": "25.0km",
+        "progress": "0.0km",
+        "dDay": "13일 남음",
+        "joined": false,
+      },
+      {
+        "title": "6월 30K 챌린지",
+        "desc": "이번 달 30km를 달려보세요.",
+        "totalDistance": "30.0km",
+        "progress": "0.0km",
+        "dDay": "13일 남음",
+        "joined": false,
+      },
     ];
 
     return Scaffold(
@@ -114,10 +170,20 @@ class ChallengeListPage extends StatelessWidget {
     );
   }
 
-  List<Widget> buildChallengeCards(List<Map<String, String>> challenges, BuildContext context) {
+  List<Widget> buildChallengeCards(
+    List<Map<String, Object>> challenges,
+    BuildContext context,
+  ) {
     return challenges.map((c) {
+      final String title = c["title"] as String;
+      final String dDay = c["dDay"] as String;
+      final String desc = c["desc"] as String;
+      final String totalDistance = c["totalDistance"] as String;
+      final String progress = c["progress"] as String;
+      final bool isJoined = c["joined"] as bool;
+
       return Card(
-        color: Color(0xFFF9FAEB),
+        color: const Color(0xFFF9FAEB),
         margin: const EdgeInsets.symmetric(vertical: 6),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
         elevation: 2,
@@ -127,10 +193,12 @@ class ChallengeListPage extends StatelessWidget {
               context,
               MaterialPageRoute(
                 builder: (context) => ChallengeDetailPage(
-                  title: c["title"] ?? '',
-                  dDay: c["dDay"] ?? '',
-                  progress: c["progress"],
-                  desc: c["desc"],
+                  title: title,
+                  dDay: dDay,
+                  progress: progress,
+                  totalDistance: totalDistance,
+                  desc: desc,
+                  isJoined: isJoined,
                 ),
               ),
             );
@@ -157,29 +225,32 @@ class ChallengeListPage extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
-                        c["title"] ?? '',
+                        title,
                         style: const TextStyle(
                           fontWeight: FontWeight.bold,
                           color: Color(0xFF021F59),
                         ),
                       ),
                       const SizedBox(height: 4),
-                      // 챌린지 진행률과 설명을 줄바꿈으로 함께 출력
-                      if (c.containsKey("progress"))
+
+                      // 설명 텍스트 (항상 표시)
+                      
+                      if(!isJoined)Text(
+                        desc,
+                        style: const TextStyle(color: Color(0xFF021F59)),
+                      ),
+
+                      // 진행률 (참여 중일 때만 표시)
+                      if (isJoined)
                         Text(
-                          c["progress"]!,
+                          "$progress / $totalDistance",
                           style: const TextStyle(color: Colors.blue),
                         ),
-                      if (c.containsKey("desc"))
-                        Text(
-                          c["desc"]!,
-                          style: const TextStyle(color: Color(0xFF021F59)),
-                        ),
-                      if (c.containsKey("dDay"))
-                        Text(
-                          c["dDay"]!,
-                          style: const TextStyle(color: Color(0xFF021F59)),
-                        ),
+
+                      Text(
+                        dDay,
+                        style: const TextStyle(color: Color(0xFF021F59)),
+                      ),
                     ],
                   ),
                 ),

--- a/lib/ui/pages/community/challenge/list_page.dart
+++ b/lib/ui/pages/community/challenge/list_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:tracky_flutter/ui/pages/community/challenge/detail_page/detail_page.dart';
 import 'package:tracky_flutter/ui/widgets/common_appbar.dart';
 
 class ChallengeListPage extends StatelessWidget {
@@ -48,7 +49,10 @@ class ChallengeListPage extends StatelessWidget {
             const SizedBox(height: 16),
             AspectRatio(
               aspectRatio: 16 / 9,
-              child: Image.asset("images/challenge_banner.png", fit: BoxFit.cover,),
+              child: Image.asset(
+                "images/challenge_banner.png",
+                fit: BoxFit.cover,
+              ),
             ),
             const SizedBox(height: 16),
             Center(
@@ -82,7 +86,7 @@ class ChallengeListPage extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 8),
-            ...buildChallengeCards(myChallenges),
+            ...buildChallengeCards(myChallenges, context),
             const Divider(height: 32),
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -103,14 +107,14 @@ class ChallengeListPage extends StatelessWidget {
                 ),
               ],
             ),
-            ...buildChallengeCards(joinableChallenges),
+            ...buildChallengeCards(joinableChallenges, context),
           ],
         ),
       ),
     );
   }
 
-  List<Widget> buildChallengeCards(List<Map<String, String>> challenges) {
+  List<Widget> buildChallengeCards(List<Map<String, String>> challenges, BuildContext context) {
     return challenges.map((c) {
       return Card(
         color: Color(0xFFF9FAEB),
@@ -119,7 +123,17 @@ class ChallengeListPage extends StatelessWidget {
         elevation: 2,
         child: InkWell(
           onTap: () {
-            debugPrint('Tapped on ${c["title"]}');
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (context) => ChallengeDetailPage(
+                  title: c["title"] ?? '',
+                  dDay: c["dDay"] ?? '',
+                  progress: c["progress"],
+                  desc: c["desc"],
+                ),
+              ),
+            );
           },
           borderRadius: BorderRadius.circular(12),
           child: Padding(
@@ -131,7 +145,10 @@ class ChallengeListPage extends StatelessWidget {
                   height: 48,
                   child: AspectRatio(
                     aspectRatio: 1 / 1,
-                    child: Image.asset("images/challenge_achievement.png", fit: BoxFit.cover,),
+                    child: Image.asset(
+                      "images/challenge_achievement.png",
+                      fit: BoxFit.cover,
+                    ),
                   ),
                 ),
                 const SizedBox(width: 12),


### PR DESCRIPTION
- 챌린지 리스트에서 카드 클릭 시 진입
- 챌린지 상단 앱바 메뉴 클릭 시 챌린지 정보, 챌린지 참가/종료 구분
- 데이터 바인딩 1차 완료 (riverpod 연결 시 수정 필요)
- 그림은 placeholder로 대체 (연결할 그림 발견 시 대체)